### PR TITLE
chore: add PR template with auto-close hint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## PR Title
+
+Short, imperative summary (e.g., chore: update Copilot guide and PR template)
+
+## Linked Issue
+
+Fixed issue #<issue-number>
+
+Note: GitHub auto-closes the linked issue on merge when using closing keywords like "Fixes #123" or "Fixed #123".
+
+## Summary
+
+What does this change do and why?
+
+## Changes
+
+- Bullet the key changes
+- Keep it concise
+
+## Screenshots / Demos (optional)
+
+If UI/visual changes, add before/after or a brief clip.
+
+## Checklist
+
+- [ ] Includes a proper closing reference (e.g., Fixes #<issue-number>)
+- [ ] Lint passes (npm run lint)
+- [ ] Tests added/updated and pass (npm test)
+- [ ] Build succeeds (npm run build)
+- [ ] Docs updated as needed (README/COPILOT.md)
+- [ ] No breaking changes, or breaking changes documented


### PR DESCRIPTION
This PR adds a repository-wide pull request template that prompts authors to include a closing keyword so issues auto-close on merge.

Key additions:
- Adds a "Linked Issue" section with the line: `Fixed issue #<issue-number>`
- Notes that closing keywords like "Fixes #123" or "Fixed #123" will auto-close the linked issue on merge
- Includes a brief checklist for linting, tests, and documentation

Why:
- Encourages consistent PR descriptions and ensures issues linked to PRs are automatically closed when merged.

No code changes; docs-only.
