### PR TITLE
feat(types): add System/Jump types and runtime data validation

### DIFF
--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -3,8 +3,11 @@ import { TrackballControls } from "three/examples/jsm/controls/TrackballControls
 import { CSS3DObject, CSS3DRenderer } from "three/examples/jsm/renderers/CSS3DRenderer.js";
 import { systemsArr } from "./systemsList";
 import { jumpList } from "./jumpLinks";
+import { validateData } from "./types";
 
 document.addEventListener("DOMContentLoaded", () => {
+  // One-time data validation for developer visibility in console
+  validateData(systemsArr, jumpList);
   type MapState = {
     systems: CSS3DObject[];
     links: CSS3DObject[];

--- a/scripts/jumpLinks.ts
+++ b/scripts/jumpLinks.ts
@@ -1,4 +1,6 @@
-export const jumpList = [
+import type { Jump } from "./types";
+
+export const jumpList: Jump[] = [
   { bridge: [0, 244], type: "D", year: 2111 },
   { bridge: [0, 65], type: "D", year: 2118 },
   { bridge: [0, 411], type: "D", year: 2122 },

--- a/scripts/systemsList.ts
+++ b/scripts/systemsList.ts
@@ -1,4 +1,6 @@
-export const systemsArr = [
+import type { System } from "./types";
+
+export const systemsArr: System[] = [
   { id: 0, x: 0.0, y: 0.0, z: 0.0, type: ["G V"], sysName: "Sol", planetName: "Earth" },
   { id: 1005, x: 0.13, y: 1.26, z: -5.15, type: ["M V"], sysName: "Luyten 722-22" },
   {

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,0 +1,47 @@
+// Strong types for systems and jumps plus a tiny runtime validator
+
+export interface System {
+  id: number;
+  x: number;
+  y: number;
+  z: number;
+  // Stellar classification(s), e.g., "G V", "K IV", or "D"; stored as strings from data source
+  type: string[];
+  sysName: string;
+  planetName?: string;
+}
+
+export type JumpType = "A" | "B" | "G" | "D" | "E";
+
+export interface Jump {
+  bridge: [number, number]; // [fromId, toId]
+  type: JumpType;
+  year: number;
+}
+
+// Build a Set of valid system IDs for quick membership checks
+export function buildSystemIdSet(systems: System[]): Set<number> {
+  const ids = new Set<number>();
+  for (const s of systems) ids.add(s.id);
+  return ids;
+}
+
+// Validate that all jump endpoints reference known system IDs. Logs a single warning per invalid pair.
+export function validateData(systems: System[], jumps: Jump[]): void {
+  const idSet = buildSystemIdSet(systems);
+  let invalidCount = 0;
+  for (const j of jumps) {
+    const [a, b] = j.bridge;
+    const aOK = idSet.has(a);
+    const bOK = idSet.has(b);
+    if (!aOK || !bOK) {
+      invalidCount++;
+      console.warn(
+        `Invalid jump reference: ${a} -> ${b} (exists: ${aOK ? "Y" : "N"} / ${bOK ? "Y" : "N"})`,
+      );
+    }
+  }
+  if (invalidCount > 0) {
+    console.warn(`Validation found ${invalidCount} invalid jump(s).`);
+  }
+}


### PR DESCRIPTION
Introduce strong typing and lightweight runtime validation for systems and jumps per issue #21.

Highlights:
- Add `scripts/types.ts` with `System`, `JumpType`, and `Jump` types
- Add `buildSystemIdSet` and `validateData` helpers
- Type `systemsArr` and `jumpList`; validate once on app start
- No behavior changes to rendering

Fixed issue #21