### PR TITLE
perf(app): precompute id→index map for jump link creation

### DIFF
--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -49,7 +49,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const dateValStr = dateSlider.value;
       const dateVal = Number(dateValStr);
       if (dateBox) dateBox.textContent = String(dateVal);
-      for (const n in jumpList) {
+      for (let n = 0; n < jumpList.length; n++) {
         if (jumpList[n].year >= dateVal) {
           mapState.links[n].element.classList.add("undiscovered");
         }
@@ -89,7 +89,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (allLinks) {
     allLinks.addEventListener("change", function (this: HTMLInputElement) {
       if (this.checked) {
-        for (const i in mapState.linkTypes) {
+        for (let i = 0; i < mapState.linkTypes.length; i++) {
           const el = mapState.linkTypes[i] as HTMLInputElement;
           if (el && el.checked === false) {
             el.checked = true;
@@ -97,7 +97,7 @@ document.addEventListener("DOMContentLoaded", () => {
           }
         }
       } else {
-        for (const j in mapState.linkTypes) {
+        for (let j = 0; j < mapState.linkTypes.length; j++) {
           const el = mapState.linkTypes[j] as HTMLInputElement;
           if (el && el.checked === true) {
             el.checked = false;
@@ -136,9 +136,8 @@ document.addEventListener("DOMContentLoaded", () => {
     );
     mapState.camera.position.z = 5000;
     mapState.scene = new THREE.Scene();
-    for (const i in systemsArr) {
+    for (const system of systemsArr) {
       const starText = "starText";
-      const system = systemsArr[i];
       const starType = system.type[0][0].toUpperCase();
       const systemDiv = document.createElement("div");
       systemDiv.className = "starDiv";
@@ -183,7 +182,7 @@ document.addEventListener("DOMContentLoaded", () => {
       mapState.systems.push(star);
     }
     const systemIndex = systemsArr.map((s) => s.id);
-    for (const j in jumpList) {
+    for (let j = 0; j < jumpList.length; j++) {
       const startPos = mapState.systems[systemIndex.indexOf(jumpList[j].bridge[0])].position;
       const endPos = mapState.systems[systemIndex.indexOf(jumpList[j].bridge[1])].position;
       mapState.tmpVec1.subVectors(endPos, startPos);
@@ -260,18 +259,18 @@ document.addEventListener("DOMContentLoaded", () => {
     mapState.render();
   };
   mapState.render = function () {
-    for (const i in mapState.systems) {
-      mapState.systems[i].lookAt(mapState.camera.position.clone());
-      mapState.systems[i].up = mapState.camera.up.clone();
-      if (mapState.systems[i].position.distanceTo(mapState.camera.position) < 500) {
-        mapState.systems[i].element.children[1].className = "invis";
-        if (mapState.systems[i].element.children[2]) {
-          mapState.systems[i].element.children[2].className = "invis";
+    for (const sys of mapState.systems) {
+      sys.lookAt(mapState.camera.position.clone());
+      sys.up = mapState.camera.up.clone();
+      if (sys.position.distanceTo(mapState.camera.position) < 500) {
+        sys.element.children[1].className = "invis";
+        if (sys.element.children[2]) {
+          sys.element.children[2].className = "invis";
         }
       } else {
-        mapState.systems[i].element.children[1].className = "starText";
-        if (mapState.systems[i].element.children[2]) {
-          mapState.systems[i].element.children[2].className = "planetText";
+        sys.element.children[1].className = "starText";
+        if (sys.element.children[2]) {
+          sys.element.children[2].className = "planetText";
         }
       }
     }

--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -181,10 +181,15 @@ document.addEventListener("DOMContentLoaded", () => {
       mapState.scene.add(star);
       mapState.systems.push(star);
     }
-    const systemIndex = systemsArr.map((s) => s.id);
+    // Precompute system id → index map for O(1) lookups (perf #14)
+    const idToIndex = new Map<number, number>();
+    for (let idx = 0; idx < systemsArr.length; idx++) idToIndex.set(systemsArr[idx].id, idx);
     for (let j = 0; j < jumpList.length; j++) {
-      const startPos = mapState.systems[systemIndex.indexOf(jumpList[j].bridge[0])].position;
-      const endPos = mapState.systems[systemIndex.indexOf(jumpList[j].bridge[1])].position;
+      const fromIdx = idToIndex.get(jumpList[j].bridge[0]);
+      const toIdx = idToIndex.get(jumpList[j].bridge[1]);
+      if (fromIdx == null || toIdx == null) continue; // invalid refs already warned by validateData
+      const startPos = mapState.systems[fromIdx].position;
+      const endPos = mapState.systems[toIdx].position;
       mapState.tmpVec1.subVectors(endPos, startPos);
       const linkLength = mapState.tmpVec1.length() - 25;
       const hyperLink = document.createElement("div");


### PR DESCRIPTION
Speed up jump link creation by precomputing a `Map<number, number>` from system id to index, replacing repeated `indexOf` calls.

Details
- Build `idToIndex` once from `systemsArr`
- Use it for O(1) lookups of from/to indices in the jump loop
- Skip rendering a link if an id is missing (already warned by validation)

No behavior changes intended.

Fixed issue #14