### PR TITLE
refactor(types): move MapState to shared types module

### DIFF
--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -4,43 +4,12 @@ import { CSS3DObject, CSS3DRenderer } from "three/examples/jsm/renderers/CSS3DRe
 import { systemsArr } from "./systemsList";
 import { jumpList } from "./jumpLinks";
 import { validateData } from "./types";
+import type { MapState } from "./types";
 
 document.addEventListener("DOMContentLoaded", () => {
   // One-time data validation for developer visibility in console
   validateData(systemsArr, jumpList);
-  type MapState = {
-    systems: CSS3DObject[];
-    links: CSS3DObject[];
-    alphaLinks: CSS3DObject[];
-    betaLinks: CSS3DObject[];
-    gammaLinks: CSS3DObject[];
-    deltaLinks: CSS3DObject[];
-    epsiLinks: CSS3DObject[];
-    linkTypes: HTMLInputElement[];
-    alphaCheckbox: HTMLInputElement | null;
-    betaCheckbox: HTMLInputElement | null;
-    gammaCheckbox: HTMLInputElement | null;
-    deltaCheckbox: HTMLInputElement | null;
-    epsiCheckbox: HTMLInputElement | null;
-    tmpVec1: THREE.Vector3;
-    tmpVec2: THREE.Vector3;
-    tmpVec3: THREE.Vector3;
-    tmpVec4: THREE.Vector3;
-    Scale: number;
-    camera: THREE.PerspectiveCamera;
-    scene: THREE.Scene;
-    renderer: CSS3DRenderer;
-    controls: TrackballControls;
-    onWindowResize: () => void;
-    animate: () => void;
-    render: () => void;
-    toggleAlpha: () => void;
-    toggleBeta: () => void;
-    toggleGamma: () => void;
-    toggleDelta: () => void;
-    toggleEpsi: () => void;
-    init: () => void;
-  };
+  // MapState is now defined in scripts/types.ts
   //the following is to link the slider with the text box*/
   const dateSlider = document.getElementById("dateSlider") as HTMLInputElement | null;
   const dateBox = document.getElementById("dateBox");

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -32,6 +32,41 @@ export interface ValidationResult {
   }>;
 }
 
+// Shared app state type used in app.ts
+export type MapState = {
+  systems: import("three/examples/jsm/renderers/CSS3DRenderer.js").CSS3DObject[];
+  links: import("three/examples/jsm/renderers/CSS3DRenderer.js").CSS3DObject[];
+  alphaLinks: import("three/examples/jsm/renderers/CSS3DRenderer.js").CSS3DObject[];
+  betaLinks: import("three/examples/jsm/renderers/CSS3DRenderer.js").CSS3DObject[];
+  gammaLinks: import("three/examples/jsm/renderers/CSS3DRenderer.js").CSS3DObject[];
+  deltaLinks: import("three/examples/jsm/renderers/CSS3DRenderer.js").CSS3DObject[];
+  epsiLinks: import("three/examples/jsm/renderers/CSS3DRenderer.js").CSS3DObject[];
+  linkTypes: HTMLInputElement[];
+  alphaCheckbox: HTMLInputElement | null;
+  betaCheckbox: HTMLInputElement | null;
+  gammaCheckbox: HTMLInputElement | null;
+  deltaCheckbox: HTMLInputElement | null;
+  epsiCheckbox: HTMLInputElement | null;
+  tmpVec1: import("three").Vector3;
+  tmpVec2: import("three").Vector3;
+  tmpVec3: import("three").Vector3;
+  tmpVec4: import("three").Vector3;
+  Scale: number;
+  camera: import("three").PerspectiveCamera;
+  scene: import("three").Scene;
+  renderer: import("three/examples/jsm/renderers/CSS3DRenderer.js").CSS3DRenderer;
+  controls: import("three/examples/jsm/controls/TrackballControls.js").TrackballControls;
+  onWindowResize: () => void;
+  animate: () => void;
+  render: () => void;
+  toggleAlpha: () => void;
+  toggleBeta: () => void;
+  toggleGamma: () => void;
+  toggleDelta: () => void;
+  toggleEpsi: () => void;
+  init: () => void;
+};
+
 // Build a Set of valid system IDs for quick membership checks
 export function buildSystemIdSet(systems: System[]): Set<number> {
   const ids = new Set<number>();


### PR DESCRIPTION
This PR moves the MapState type definition from scripts/app.ts into the shared scripts/types.ts module, and imports it where used.

Why
- Centralize shared types for reuse and consistency
- Reduce clutter in app.ts

Changes
- Add export type MapState in scripts/types.ts (using type-only inline imports for Three/CSS3D types)
- Remove inline MapState from scripts/app.ts and import type { MapState } from './types'

Notes
- No behavior changes intended
- Lint/tests/build pass locally

Fixed issue #35