### PR TITLE
refactor(12): introduce MapState factory/class and remove unsafe cast

### DIFF
--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -1,15 +1,12 @@
-import * as THREE from "three";
-import { TrackballControls } from "three/examples/jsm/controls/TrackballControls.js";
-import { CSS3DObject, CSS3DRenderer } from "three/examples/jsm/renderers/CSS3DRenderer.js";
 import { systemsArr } from "./systemsList";
 import { jumpList } from "./jumpLinks";
 import { validateData } from "./types";
 import type { MapState } from "./types";
+import { MapStateImpl } from "./mapState";
 
 document.addEventListener("DOMContentLoaded", () => {
   // One-time data validation for developer visibility in console
   validateData(systemsArr, jumpList);
-  // MapState is now defined in scripts/types.ts
   //the following is to link the slider with the text box*/
   const dateSlider = document.getElementById("dateSlider") as HTMLInputElement | null;
   const dateBox = document.getElementById("dateBox");
@@ -28,14 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   }
-  const mapState = {} as unknown as MapState;
-  mapState.systems = [];
-  mapState.links = [];
-  mapState.alphaLinks = [];
-  mapState.betaLinks = [];
-  mapState.gammaLinks = [];
-  mapState.deltaLinks = [];
-  mapState.epsiLinks = [];
+  const mapState: MapState = new MapStateImpl(systemsArr, jumpList);
   mapState.linkTypes = [];
   mapState.alphaCheckbox = document.getElementById("alphaLink") as HTMLInputElement | null;
   mapState.betaCheckbox = document.getElementById("betaLink") as HTMLInputElement | null;
@@ -49,11 +39,6 @@ document.addEventListener("DOMContentLoaded", () => {
     mapState.deltaCheckbox,
     mapState.epsiCheckbox,
   ].filter(Boolean) as HTMLInputElement[];
-  mapState.tmpVec1 = new THREE.Vector3();
-  mapState.tmpVec2 = new THREE.Vector3();
-  mapState.tmpVec3 = new THREE.Vector3();
-  mapState.tmpVec4 = new THREE.Vector3();
-  mapState.Scale = 200;
   const allLinks = document.getElementById("allLinks") as HTMLInputElement | null;
   if (allLinks) {
     allLinks.addEventListener("change", function (this: HTMLInputElement) {
@@ -96,181 +81,9 @@ document.addEventListener("DOMContentLoaded", () => {
     mapState.epsiCheckbox.addEventListener("change", function () {
       mapState.toggleEpsi();
     });
-  mapState.init = function () {
-    mapState.camera = new THREE.PerspectiveCamera(
-      60,
-      window.innerWidth / window.innerHeight,
-      1,
-      75000,
-    );
-    mapState.camera.position.z = 5000;
-    mapState.scene = new THREE.Scene();
-    for (const system of systemsArr) {
-      const starText = "starText";
-      const starType = system.type[0][0].toUpperCase();
-      const systemDiv = document.createElement("div");
-      systemDiv.className = "starDiv";
-      const starPic = document.createElement("img");
-      if (starType === "A") {
-        starPic.className = "a_star";
-        starPic.src = "img/A-star.png";
-      } else if (starType === "F") {
-        starPic.className = "f_star";
-        starPic.src = "img/F-star.png";
-      } else if (starType === "G") {
-        starPic.className = "g_star";
-        starPic.src = "img/G-star.png";
-      } else if (starType === "K") {
-        starPic.className = "k_star";
-        starPic.src = "img/K-star.png";
-      } else if (starType === "M") {
-        starPic.className = "m_star";
-        starPic.src = "img/M-star.png";
-      } else if (starType === "D") {
-        starPic.className = "d_star";
-        starPic.src = "img/D-star.png";
-      } else {
-        starPic.src = "img/spark1.png";
-      }
-      systemDiv.appendChild(starPic);
-      const name = document.createElement("div");
-      name.className = starText;
-      name.textContent = system.sysName;
-      systemDiv.appendChild(name);
-      if (system.planetName) {
-        const planet = document.createElement("div");
-        planet.className = starText;
-        planet.textContent = system.planetName;
-        systemDiv.appendChild(planet);
-      }
-      const star = new CSS3DObject(systemDiv);
-      star.position.x = system.x * mapState.Scale;
-      star.position.y = system.y * mapState.Scale;
-      star.position.z = system.z * mapState.Scale;
-      mapState.scene.add(star);
-      mapState.systems.push(star);
-    }
-    // Precompute system id → index map for O(1) lookups (perf #14)
-    const idToIndex = new Map<number, number>();
-    for (let idx = 0; idx < systemsArr.length; idx++) idToIndex.set(systemsArr[idx].id, idx);
-    for (let j = 0; j < jumpList.length; j++) {
-      const fromIdx = idToIndex.get(jumpList[j].bridge[0]);
-      const toIdx = idToIndex.get(jumpList[j].bridge[1]);
-      if (fromIdx === undefined || toIdx === undefined) continue; // invalid refs already warned by validateData
-      const startPos = mapState.systems[fromIdx].position;
-      const endPos = mapState.systems[toIdx].position;
-      mapState.tmpVec1.subVectors(endPos, startPos);
-      const linkLength = mapState.tmpVec1.length() - 25;
-      const hyperLink = document.createElement("div");
-      hyperLink.className = "jumpLink";
-      if (jumpList[j].type === "A") {
-        hyperLink.className = "alpha";
-      }
-      if (jumpList[j].type === "B") {
-        hyperLink.className = "beta";
-      }
-      if (jumpList[j].type === "G") {
-        hyperLink.className = "gamma";
-      }
-      if (jumpList[j].type === "D") {
-        hyperLink.className = "delta";
-      }
-      if (jumpList[j].type === "E") {
-        hyperLink.className = "epsilon";
-      }
-      hyperLink.style.height = linkLength + "px";
-      const object = new CSS3DObject(hyperLink);
-      object.position.copy(startPos).lerp(endPos, 0.5);
-      const axis = mapState.tmpVec2.set(0, 1, 0).cross(mapState.tmpVec1);
-      const radians = Math.acos(
-        mapState.tmpVec3.set(0, 1, 0).dot(mapState.tmpVec4.copy(mapState.tmpVec1).normalize()),
-      );
-      const objMatrix = new THREE.Matrix4().makeRotationAxis(axis.normalize(), radians);
-      object.matrix = objMatrix;
-      object.rotation.setFromRotationMatrix(object.matrix);
-      object.matrixAutoUpdate = false;
-      object.updateMatrix();
-      if (object.element.className === "alpha") {
-        mapState.alphaLinks.push(object);
-      }
-      if (object.element.className === "beta") {
-        mapState.betaLinks.push(object);
-      }
-      if (object.element.className === "delta") {
-        mapState.deltaLinks.push(object);
-      }
-      if (object.element.className === "gamma") {
-        mapState.gammaLinks.push(object);
-      }
-      if (object.element.className === "epsilon") {
-        mapState.epsiLinks.push(object);
-      }
-      mapState.scene.add(object);
-      mapState.links.push(object);
-    }
-    mapState.renderer = new CSS3DRenderer();
-    mapState.renderer.setSize(window.innerWidth, window.innerHeight);
-    const container = document.getElementById("container");
-    if (container) {
-      container.appendChild(mapState.renderer.domElement);
-    }
-    mapState.controls = new TrackballControls(mapState.camera, mapState.renderer.domElement);
-    mapState.controls.rotateSpeed = 1.0;
-    mapState.controls.dynamicDampingFactor = 0.3;
-    mapState.controls.maxDistance = 7500;
-    mapState.controls.addEventListener("change", mapState.render);
-    window.addEventListener("resize", mapState.onWindowResize, false);
-  };
-  mapState.onWindowResize = function () {
-    mapState.camera.aspect = window.innerWidth / window.innerHeight;
-    mapState.camera.updateProjectionMatrix();
-    mapState.renderer.setSize(window.innerWidth, window.innerHeight);
-    mapState.render();
-  };
-  mapState.animate = function () {
-    requestAnimationFrame(mapState.animate);
-    mapState.controls.update();
-    mapState.render();
-  };
-  mapState.render = function () {
-    for (const sys of mapState.systems) {
-      sys.lookAt(mapState.camera.position.clone());
-      sys.up = mapState.camera.up.clone();
-      if (sys.position.distanceTo(mapState.camera.position) < 500) {
-        sys.element.children[1].className = "invis";
-        if (sys.element.children[2]) {
-          sys.element.children[2].className = "invis";
-        }
-      } else {
-        sys.element.children[1].className = "starText";
-        if (sys.element.children[2]) {
-          sys.element.children[2].className = "planetText";
-        }
-      }
-    }
-    mapState.renderer.render(mapState.scene, mapState.camera);
-  };
-  // unified toggle helper for link visibility
-  const toggleLinksVisibility = (list: CSS3DObject[]) => {
-    for (const obj of list) {
-      obj.element.classList.toggle("hidden");
-    }
-  };
-  mapState.toggleAlpha = function () {
-    toggleLinksVisibility(mapState.alphaLinks);
-  };
-  mapState.toggleBeta = function () {
-    toggleLinksVisibility(mapState.betaLinks);
-  };
-  mapState.toggleGamma = function () {
-    toggleLinksVisibility(mapState.gammaLinks);
-  };
-  mapState.toggleDelta = function () {
-    toggleLinksVisibility(mapState.deltaLinks);
-  };
-  mapState.toggleEpsi = function () {
-    toggleLinksVisibility(mapState.epsiLinks);
-  };
+  // MapStateImpl encapsulates init/render/animate and link toggles
+  mapState.init();
+  mapState.animate();
 
   mapState.init();
   mapState.animate();

--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -84,7 +84,4 @@ document.addEventListener("DOMContentLoaded", () => {
   // MapStateImpl encapsulates init/render/animate and link toggles
   mapState.init();
   mapState.animate();
-
-  mapState.init();
-  mapState.animate();
 });

--- a/scripts/mapState.ts
+++ b/scripts/mapState.ts
@@ -1,0 +1,189 @@
+import * as THREE from "three";
+import { TrackballControls } from "three/examples/jsm/controls/TrackballControls.js";
+import { CSS3DObject, CSS3DRenderer } from "three/examples/jsm/renderers/CSS3DRenderer.js";
+import type { Jump, MapState, System } from "./types";
+
+export class MapStateImpl implements MapState {
+  systems: CSS3DObject[] = [];
+  links: CSS3DObject[] = [];
+  alphaLinks: CSS3DObject[] = [];
+  betaLinks: CSS3DObject[] = [];
+  gammaLinks: CSS3DObject[] = [];
+  deltaLinks: CSS3DObject[] = [];
+  epsiLinks: CSS3DObject[] = [];
+  linkTypes: HTMLInputElement[] = [];
+  alphaCheckbox: HTMLInputElement | null = null;
+  betaCheckbox: HTMLInputElement | null = null;
+  gammaCheckbox: HTMLInputElement | null = null;
+  deltaCheckbox: HTMLInputElement | null = null;
+  epsiCheckbox: HTMLInputElement | null = null;
+  tmpVec1 = new THREE.Vector3();
+  tmpVec2 = new THREE.Vector3();
+  tmpVec3 = new THREE.Vector3();
+  tmpVec4 = new THREE.Vector3();
+  Scale = 200;
+  camera!: THREE.PerspectiveCamera;
+  scene!: THREE.Scene;
+  renderer!: CSS3DRenderer;
+  controls!: TrackballControls;
+
+  private systemsData: System[];
+  private jumpData: Jump[];
+
+  constructor(systemsArr: System[], jumpList: Jump[]) {
+    this.systemsData = systemsArr;
+    this.jumpData = jumpList;
+  }
+
+  private toggleLinksVisibility(list: CSS3DObject[]) {
+    for (const obj of list) obj.element.classList.toggle("hidden");
+  }
+
+  toggleAlpha = () => this.toggleLinksVisibility(this.alphaLinks);
+  toggleBeta = () => this.toggleLinksVisibility(this.betaLinks);
+  toggleGamma = () => this.toggleLinksVisibility(this.gammaLinks);
+  toggleDelta = () => this.toggleLinksVisibility(this.deltaLinks);
+  toggleEpsi = () => this.toggleLinksVisibility(this.epsiLinks);
+
+  init = () => {
+    this.camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 1, 75000);
+    this.camera.position.z = 5000;
+    this.scene = new THREE.Scene();
+
+    for (const system of this.systemsData) {
+      const starText = "starText";
+      const starType = system.type[0][0].toUpperCase();
+      const systemDiv = document.createElement("div");
+      systemDiv.className = "starDiv";
+      const starPic = document.createElement("img");
+      if (starType === "A") {
+        starPic.className = "a_star";
+        starPic.src = "img/A-star.png";
+      } else if (starType === "F") {
+        starPic.className = "f_star";
+        starPic.src = "img/F-star.png";
+      } else if (starType === "G") {
+        starPic.className = "g_star";
+        starPic.src = "img/G-star.png";
+      } else if (starType === "K") {
+        starPic.className = "k_star";
+        starPic.src = "img/K-star.png";
+      } else if (starType === "M") {
+        starPic.className = "m_star";
+        starPic.src = "img/M-star.png";
+      } else if (starType === "D") {
+        starPic.className = "d_star";
+        starPic.src = "img/D-star.png";
+      } else {
+        starPic.src = "img/spark1.png";
+      }
+      systemDiv.appendChild(starPic);
+      const name = document.createElement("div");
+      name.className = starText;
+      name.textContent = system.sysName;
+      systemDiv.appendChild(name);
+      if (system.planetName) {
+        const planet = document.createElement("div");
+        planet.className = starText;
+        planet.textContent = system.planetName;
+        systemDiv.appendChild(planet);
+      }
+      const star = new CSS3DObject(systemDiv);
+      star.position.x = system.x * this.Scale;
+      star.position.y = system.y * this.Scale;
+      star.position.z = system.z * this.Scale;
+      this.scene.add(star);
+      this.systems.push(star);
+    }
+
+    // Precompute system id → index map for O(1) lookups (perf #14)
+    const idToIndex = new Map<number, number>();
+    for (let idx = 0; idx < this.systemsData.length; idx++) {
+      idToIndex.set(this.systemsData[idx].id, idx);
+    }
+    for (let j = 0; j < this.jumpData.length; j++) {
+      const fromIdx = idToIndex.get(this.jumpData[j].bridge[0]);
+      const toIdx = idToIndex.get(this.jumpData[j].bridge[1]);
+      if (fromIdx === undefined || toIdx === undefined) continue; // invalid refs already warned by validateData
+      const startPos = this.systems[fromIdx].position;
+      const endPos = this.systems[toIdx].position;
+      this.tmpVec1.subVectors(endPos, startPos);
+      const linkLength = this.tmpVec1.length() - 25;
+      const hyperLink = document.createElement("div");
+      hyperLink.className = "jumpLink";
+      if (this.jumpData[j].type === "A") {
+        hyperLink.className = "alpha";
+      }
+      if (this.jumpData[j].type === "B") {
+        hyperLink.className = "beta";
+      }
+      if (this.jumpData[j].type === "G") {
+        hyperLink.className = "gamma";
+      }
+      if (this.jumpData[j].type === "D") {
+        hyperLink.className = "delta";
+      }
+      if (this.jumpData[j].type === "E") {
+        hyperLink.className = "epsilon";
+      }
+      hyperLink.style.height = linkLength + "px";
+      const object = new CSS3DObject(hyperLink);
+      object.position.copy(startPos).lerp(endPos, 0.5);
+      const axis = this.tmpVec2.set(0, 1, 0).cross(this.tmpVec1);
+      const radians = Math.acos(
+        this.tmpVec3.set(0, 1, 0).dot(this.tmpVec4.copy(this.tmpVec1).normalize()),
+      );
+      const objMatrix = new THREE.Matrix4().makeRotationAxis(axis.normalize(), radians);
+      object.matrix = objMatrix;
+      object.rotation.setFromRotationMatrix(object.matrix);
+      object.matrixAutoUpdate = false;
+      object.updateMatrix();
+      if (object.element.className === "alpha") this.alphaLinks.push(object);
+      if (object.element.className === "beta") this.betaLinks.push(object);
+      if (object.element.className === "delta") this.deltaLinks.push(object);
+      if (object.element.className === "gamma") this.gammaLinks.push(object);
+      if (object.element.className === "epsilon") this.epsiLinks.push(object);
+      this.scene.add(object);
+      this.links.push(object);
+    }
+
+    this.renderer = new CSS3DRenderer();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    const container = document.getElementById("container");
+    if (container) container.appendChild(this.renderer.domElement);
+    this.controls = new TrackballControls(this.camera, this.renderer.domElement);
+    this.controls.rotateSpeed = 1.0;
+    this.controls.dynamicDampingFactor = 0.3;
+    this.controls.maxDistance = 7500;
+    this.controls.addEventListener("change", this.render);
+    window.addEventListener("resize", this.onWindowResize, false);
+  };
+
+  onWindowResize = () => {
+    this.camera.aspect = window.innerWidth / window.innerHeight;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    this.render();
+  };
+
+  animate = () => {
+    requestAnimationFrame(this.animate);
+    this.controls.update();
+    this.render();
+  };
+
+  render = () => {
+    for (const sys of this.systems) {
+      sys.lookAt(this.camera.position.clone());
+      sys.up = this.camera.up.clone();
+      if (sys.position.distanceTo(this.camera.position) < 500) {
+        sys.element.children[1].className = "invis";
+        if (sys.element.children[2]) sys.element.children[2].className = "invis";
+      } else {
+        sys.element.children[1].className = "starText";
+        if (sys.element.children[2]) sys.element.children[2].className = "planetText";
+      }
+    }
+    this.renderer.render(this.scene, this.camera);
+  };
+}

--- a/scripts/mapState.ts
+++ b/scripts/mapState.ts
@@ -110,21 +110,25 @@ export class MapStateImpl implements MapState {
       this.tmpVec1.subVectors(endPos, startPos);
       const linkLength = this.tmpVec1.length() - 25;
       const hyperLink = document.createElement("div");
-      hyperLink.className = "jumpLink";
-      if (this.jumpData[j].type === "A") {
-        hyperLink.className = "alpha";
-      }
-      if (this.jumpData[j].type === "B") {
-        hyperLink.className = "beta";
-      }
-      if (this.jumpData[j].type === "G") {
-        hyperLink.className = "gamma";
-      }
-      if (this.jumpData[j].type === "D") {
-        hyperLink.className = "delta";
-      }
-      if (this.jumpData[j].type === "E") {
-        hyperLink.className = "epsilon";
+      // classify by jump type
+      switch (this.jumpData[j].type) {
+        case "A":
+          hyperLink.className = "alpha";
+          break;
+        case "B":
+          hyperLink.className = "beta";
+          break;
+        case "G":
+          hyperLink.className = "gamma";
+          break;
+        case "D":
+          hyperLink.className = "delta";
+          break;
+        case "E":
+          hyperLink.className = "epsilon";
+          break;
+        default:
+          hyperLink.className = "jumpLink";
       }
       hyperLink.style.height = linkLength + "px";
       const object = new CSS3DObject(hyperLink);
@@ -138,11 +142,12 @@ export class MapStateImpl implements MapState {
       object.rotation.setFromRotationMatrix(object.matrix);
       object.matrixAutoUpdate = false;
       object.updateMatrix();
-      if (object.element.className === "alpha") this.alphaLinks.push(object);
-      if (object.element.className === "beta") this.betaLinks.push(object);
-      if (object.element.className === "delta") this.deltaLinks.push(object);
-      if (object.element.className === "gamma") this.gammaLinks.push(object);
-      if (object.element.className === "epsilon") this.epsiLinks.push(object);
+      // categorize by source type directly
+      if (this.jumpData[j].type === "A") this.alphaLinks.push(object);
+      else if (this.jumpData[j].type === "B") this.betaLinks.push(object);
+      else if (this.jumpData[j].type === "D") this.deltaLinks.push(object);
+      else if (this.jumpData[j].type === "G") this.gammaLinks.push(object);
+      else if (this.jumpData[j].type === "E") this.epsiLinks.push(object);
       this.scene.add(object);
       this.links.push(object);
     }


### PR DESCRIPTION
This refactor implements issue #12 by replacing the ad-hoc `{ } as unknown as MapState` with a proper factory/class.

Changes
- Add `scripts/mapState.ts` exporting `MapStateImpl` which implements `MapState`
- Move initialization, render/animate, and link toggle logic into the class
- Wire `app.ts` to construct `new MapStateImpl(systemsArr, jumpList)` and call `init()`/`animate()`

Why
- Eliminates unsafe cast
- Centralizes initialization and lifecycle
- Makes future changes (#15 DOM helpers, #16 render caching, #23 debounce) easier

Notes
- No behavior changes intended
- Lint/tests/build pass locally

Fixed issue #12