### PR TITLE
chore(test): use 'vitest run' by default; add test:watch; update README and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm run lint:ci
 
       - name: Run tests
-        run: npm test -- --run
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint . --ext .ts,.tsx,.js,.cjs",
     "lint:ci": "eslint . --ext .ts,.tsx,.js,.cjs --max-warnings=0",
     "lint:fix": "eslint . --ext .ts,.tsx,.js,.cjs --fix",

--- a/readme.md
+++ b/readme.md
@@ -48,13 +48,14 @@ Data sources:
 ## Scripts
 
 ```bash
-npm run dev       # start Vite dev server
-npm run build     # production build
-npm test          # run vitest (watch by default)
-npm run lint      # eslint (warnings allowed)
-npm run lint:ci   # eslint with max-warnings=0 (CI)
-npm run lint:fix  # fix autofixable issues
-npm run format    # prettier write
+npm run dev        # start Vite dev server
+npm run build      # production build
+npm test           # single test run (non-watch)
+npm run test:watch # vitest in watch mode (local dev)
+npm run lint       # eslint (warnings allowed)
+npm run lint:ci    # eslint with max-warnings=0 (CI)
+npm run lint:fix   # fix autofixable issues
+npm run format     # prettier write
 ```
 
 ## Dependencies
@@ -82,8 +83,8 @@ Key files:
 Vitest runs in a jsdom environment (see `vite.config.js`).
 
 ```bash
-npm test          # watch mode
-npm test -- --run # single run (CI-style)
+npm test           # single run
+npm run test:watch # watch mode
 ```
 
 ## Contributing


### PR DESCRIPTION
This updates the test command to run once by default and avoids watch mode in CI/automation.

Changes
- package.json: `test` -> `vitest run`, add `test:watch`
- README: reflect new commands, clarify single-run vs watch
- CI: use `npm test` (non-watch) instead of passing `-- --run`

Why
- Ensure non-interactive, single-pass test execution for CI and scripts
- Keep a convenient watch mode for local development

Validation
- Lint/tests/build pass locally

Fixed issue #38